### PR TITLE
Horizon secret seed

### DIFF
--- a/app/src/main/java/blockeq/com/stellarwallet/activities/AssetsActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/AssetsActivity.kt
@@ -159,7 +159,6 @@ class AssetsActivity : BasePopupActivity(), CheckPinListener {
                     Toast.makeText(this@AssetsActivity, getString(R.string.error_trustline_changed), Toast.LENGTH_SHORT).show()
                     progressBar.visibility = View.GONE
                 }
-
             }, assetToChange!!, isRemove!!, secretSeed).execute()
         } else {
             NetworkUtils(this).displayNoNetwork()

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/InflationActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/InflationActivity.kt
@@ -41,6 +41,7 @@ class InflationActivity : BaseActivity() {
                         Horizon.Companion.JoinInflationDestination(object : SuccessErrorCallback {
                             override fun onSuccess() {
                                 Toast.makeText(this@InflationActivity, getString(R.string.inflation_set_success), Toast.LENGTH_SHORT).show()
+                                finish()
                             }
 
                             override fun onError() {

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/InflationActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/InflationActivity.kt
@@ -46,7 +46,6 @@ class InflationActivity : BaseActivity() {
                             override fun onError() {
                                 Toast.makeText(this@InflationActivity, getString(R.string.inflation_set_error), Toast.LENGTH_SHORT).show()
                             }
-
                         }, secretSeed, addressEditText.text.toString()).execute()
                     } else {
                         NetworkUtils(this).displayNoNetwork()

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/InflationActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/InflationActivity.kt
@@ -1,10 +1,13 @@
 package blockeq.com.stellarwallet.activities
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import blockeq.com.stellarwallet.R
 import blockeq.com.stellarwallet.helpers.Constants
 import blockeq.com.stellarwallet.interfaces.SuccessErrorCallback
+import blockeq.com.stellarwallet.models.PinType
 import blockeq.com.stellarwallet.services.networking.Horizon
 import blockeq.com.stellarwallet.utils.NetworkUtils
 import kotlinx.android.synthetic.main.activity_inflation.*
@@ -23,19 +26,34 @@ class InflationActivity : BaseActivity() {
         addressEditText.setText(Constants.INFLATION_DESTINATION)
 
         saveButton.setOnClickListener {
-            if (NetworkUtils(this).isNetworkAvailable()) {
-                Horizon.Companion.JoinInflationDestination(object : SuccessErrorCallback {
-                    override fun onSuccess() {
-                        Toast.makeText(this@InflationActivity, "Inflation destination set!", Toast.LENGTH_SHORT).show()
-                    }
+            launchPINView(PinType.CHECK, "", "", false)
+        }
+    }
 
-                    override fun onError() {
-                        Toast.makeText(this@InflationActivity, "There was an error setting inflation destination.", Toast.LENGTH_SHORT).show()
-                    }
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == PinActivity.PIN_REQUEST_CODE) {
+            when (resultCode) {
+                Activity.RESULT_OK -> {
+                    val secretSeed = data!!.getCharArrayExtra(PinActivity.KEY_SECRET_SEED)
 
-                }, addressEditText.text.toString()).execute()
-            } else {
-                NetworkUtils(this).displayNoNetwork()
+                    if (NetworkUtils(this).isNetworkAvailable()) {
+                        Horizon.Companion.JoinInflationDestination(object : SuccessErrorCallback {
+                            override fun onSuccess() {
+                                Toast.makeText(this@InflationActivity, getString(R.string.inflation_set_success), Toast.LENGTH_SHORT).show()
+                            }
+
+                            override fun onError() {
+                                Toast.makeText(this@InflationActivity, getString(R.string.inflation_set_error), Toast.LENGTH_SHORT).show()
+                            }
+
+                        }, secretSeed, addressEditText.text.toString()).execute()
+                    } else {
+                        NetworkUtils(this).displayNoNetwork()
+                    }
+                }
+                Activity.RESULT_CANCELED -> {}
+                else -> finish()
             }
         }
     }

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
@@ -17,7 +17,6 @@ import blockeq.com.stellarwallet.models.PinViewState
 import com.andrognito.pinlockview.PinLockListener
 import com.soneso.stellarmnemonics.Wallet
 import kotlinx.android.synthetic.main.activity_pin.*
-import org.stellar.sdk.KeyPair
 
 class PinActivity : BaseActivity(), PinLockListener {
 
@@ -26,6 +25,7 @@ class PinActivity : BaseActivity(), PinLockListener {
         const val RESULT_FAIL = 2
 
         const val MAX_ATTEMPTS = 3
+        const val KEY_SECRET_SEED = "kDecryptedPhrase"
     }
 
     private var needConfirm = true
@@ -98,7 +98,10 @@ class PinActivity : BaseActivity(), PinLockListener {
                             launchWallet()
                         }
                         pinViewState!!.type == PinType.CHECK -> {
-                            setResult(Activity.RESULT_OK)
+                            val keyPair = Wallet.createKeyPair(decryptedData.toCharArray(), null, Constants.USER_INDEX)
+                            val intent = Intent()
+                            intent.putExtra(KEY_SECRET_SEED, keyPair.secretSeed)
+                            setResult(Activity.RESULT_OK, intent)
                             finishActivity()
                         }
                         pinViewState!!.type == PinType.CLEAR_WALLET -> wipeAndRestart()

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/SendActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/SendActivity.kt
@@ -57,7 +57,10 @@ class SendActivity : BasePopupActivity(), NumberKeyboardListener, SuccessErrorCa
                 Activity.RESULT_OK -> {
                     if (NetworkUtils(this).isNetworkAvailable()) {
                         progressBar.visibility = View.VISIBLE
-                        Horizon.Companion.SendTask(this, address,
+
+                        val secretSeed = data!!.getCharArrayExtra(PinActivity.KEY_SECRET_SEED)
+
+                        Horizon.Companion.SendTask(this, address, secretSeed,
                                 memoTextView.text.toString(), amountTextView.text.toString()).execute()
                     } else {
                         NetworkUtils(this).displayNoNetwork()

--- a/app/src/main/java/blockeq/com/stellarwallet/adapters/AssetsRecyclerViewAdapter.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/adapters/AssetsRecyclerViewAdapter.kt
@@ -2,7 +2,6 @@ package blockeq.com.stellarwallet.adapters
 
 import android.app.Activity
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.support.v7.app.AlertDialog
 import android.support.v7.widget.RecyclerView
@@ -12,18 +11,14 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
-import android.widget.Toast
 import blockeq.com.stellarwallet.R
 import blockeq.com.stellarwallet.WalletApplication
 import blockeq.com.stellarwallet.activities.InflationActivity
 import blockeq.com.stellarwallet.helpers.Constants
-import blockeq.com.stellarwallet.interfaces.RecyclerViewListener
-import blockeq.com.stellarwallet.interfaces.SuccessErrorCallback
+import blockeq.com.stellarwallet.interfaces.CheckPinListener
 import blockeq.com.stellarwallet.models.SupportedAsset
 import blockeq.com.stellarwallet.models.SupportedAssetType
-import blockeq.com.stellarwallet.services.networking.Horizon
 import blockeq.com.stellarwallet.utils.AccountUtils
-import blockeq.com.stellarwallet.utils.NetworkUtils
 import blockeq.com.stellarwallet.utils.StringFormat
 import com.squareup.picasso.Picasso
 import org.stellar.sdk.Asset
@@ -31,7 +26,7 @@ import org.stellar.sdk.KeyPair
 import java.util.*
 
 
-class AssetsRecyclerViewAdapter(var context: Context, var listener: RecyclerViewListener,
+class AssetsRecyclerViewAdapter(var context: Context, var listener: CheckPinListener,
                                 var items : ArrayList<Any>) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     companion object {
@@ -154,8 +149,7 @@ class AssetsRecyclerViewAdapter(var context: Context, var listener: RecyclerView
             viewHolder.assetButton!!.text = context.getString(R.string.remove_asset_message)
             viewHolder.assetButton!!.setBackgroundColor(context.resources.getColor(R.color.apricot))
             viewHolder.assetButton!!.setOnClickListener {
-                listener.showProgressBar()
-                changeTrustLine(asset.asset!!, true)
+                listener.checkPin(asset.asset!!, true)
             }
         } else {
             viewHolder.assetButton!!.visibility = View.GONE
@@ -192,8 +186,7 @@ class AssetsRecyclerViewAdapter(var context: Context, var listener: RecyclerView
         viewHolder.assetButton!!.text = context.getString(R.string.add_asset)
         viewHolder.assetButton!!.setBackgroundColor(context.resources.getColor(R.color.mantis))
         viewHolder.assetButton!!.setOnClickListener {
-            listener.showProgressBar()
-            changeTrustLine(trustLineAsset, false)
+            listener.checkPin(trustLineAsset, false)
         }
         viewHolder.assetButton!!.visibility = View.VISIBLE
     }
@@ -211,24 +204,4 @@ class AssetsRecyclerViewAdapter(var context: Context, var listener: RecyclerView
     }
     //endregion
 
-    private fun changeTrustLine(asset: Asset, removeTrust: Boolean) {
-        if (NetworkUtils(context).isNetworkAvailable()) {
-            Horizon.Companion.ChangeTrust(object : SuccessErrorCallback {
-                override fun onSuccess() {
-                    Toast.makeText(context, context.getString(R.string.success_trustline_changed), Toast.LENGTH_SHORT).show()
-                    listener.hideProgressBar()
-                    listener.reloadDataForAdapter()
-                }
-
-                override fun onError() {
-                    Toast.makeText(context, context.getString(R.string.error_trustline_changed), Toast.LENGTH_SHORT).show()
-                    listener.hideProgressBar()
-                }
-
-            }, asset, removeTrust).execute()
-        } else {
-            NetworkUtils(context).displayNoNetwork()
-            listener.hideProgressBar()
-        }
-    }
 }

--- a/app/src/main/java/blockeq/com/stellarwallet/interfaces/CheckPinListener.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/interfaces/CheckPinListener.kt
@@ -1,0 +1,7 @@
+package blockeq.com.stellarwallet.interfaces
+
+import org.stellar.sdk.Asset
+
+interface CheckPinListener {
+    fun checkPin(asset: Asset, isRemoveAsset: Boolean)
+}

--- a/app/src/main/java/blockeq/com/stellarwallet/interfaces/RecyclerViewListener.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/interfaces/RecyclerViewListener.kt
@@ -1,7 +1,0 @@
-package blockeq.com.stellarwallet.interfaces
-
-interface RecyclerViewListener {
-    fun showProgressBar()
-    fun hideProgressBar()
-    fun reloadDataForAdapter()
-}

--- a/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
@@ -128,6 +128,7 @@ class Horizon {
         }
 
         class JoinInflationDestination(private val listener: SuccessErrorCallback,
+                                       private val secretSeed: CharArray,
                                        private val inflationDest : String)
             : AsyncTask<Void, Void, Exception>() {
 
@@ -135,7 +136,7 @@ class Horizon {
                 Network.usePublicNetwork()
 
                 val server = Server(PROD_SERVER)
-                val sourceKeyPair = KeyPair.fromAccountId(WalletApplication.localStore!!.publicKey)
+                val sourceKeyPair = KeyPair.fromSecretSeed(secretSeed)
                 val destKeyPair = KeyPair.fromAccountId(inflationDest)
 
                 try {

--- a/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
@@ -168,14 +168,14 @@ class Horizon {
         }
 
         class ChangeTrust(private val listener: SuccessErrorCallback, private val asset: Asset,
-                          private val removeTrust: Boolean)
+                          private val removeTrust: Boolean, private val secretSeed: CharArray)
             : AsyncTask<Void, Void, Exception>() {
 
             override fun doInBackground(vararg params: Void?): Exception? {
                 Network.usePublicNetwork()
 
                 val server = Server(PROD_SERVER)
-                val sourceKeyPair = KeyPair.fromAccountId(WalletApplication.localStore!!.publicKey)
+                val sourceKeyPair = KeyPair.fromSecretSeed(secretSeed)
                 val limit = if (removeTrust) "0.0000000" else Constants.MAX_ASSET_STRING_VALUE
 
                 try {

--- a/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
@@ -67,10 +67,11 @@ class Horizon {
         }
 
         class SendTask(private val listener: SuccessErrorCallback, private val destAddress: String,
-                       private val memo: String, private val amount : String) : AsyncTask<Void, Void, Exception>() {
+                       private val secretSeed: CharArray, private val memo: String,
+                       private val amount : String) : AsyncTask<Void, Void, Exception>() {
 
             override fun doInBackground(vararg params: Void?): Exception? {
-                val sourceKeyPair = KeyPair.fromAccountId(WalletApplication.localStore!!.publicKey)
+                val sourceKeyPair = KeyPair.fromSecretSeed(secretSeed)
                 val server = Server(PROD_SERVER)
                 val destKeyPair = KeyPair.fromAccountId(destAddress)
                 var isCreateAccount = false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,8 @@
     <string name="inflation_info_message">We recommend setting your inflation destination to the lumenaut community pool (entered above), which pays out 100% of inflation proceeds every Tuesday without taking any fees. You can change it to any other pool should you prefer to.</string>
     <string name="save_button">Save</string>
     <string name="inflation_destination_title">Inflation Destination</string>
+    <string name="inflation_set_success">Inflation destination set!</string>
+    <string name="inflation_set_error">There was an error setting inflation destination.</string>
 
     <!--Balance Summary Activity-->
     <string name="total_balance">Total Balance</string>


### PR DESCRIPTION
### Features

- When I was removing dependency on `KeyPair` in PR #34 I also removed getting the secret seed for certain transactions that require it and PIN
- So I've added that functionality back for `Send`, `Inflation`, and `ChangeTrust`

### For Friday
- I've written the code with the onActivityResult in a way that will make refactoring all the Pin logic easier, I'm planning to refactor it tomorrow.
  - The way I'm going to refactor is basically let every `launchPin` method to include a listener/callback where the logic can be put right in that activity, instead of being tied to the PinActivity. That way, PinActivity is only responsible for checking the PIN and returning the secret seed generated with the decrypted phrase.