### PR TITLE
Import secret seed

### DIFF
--- a/app/src/main/java/blockeq/com/stellarwallet/activities/LoginActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/LoginActivity.kt
@@ -37,7 +37,7 @@ class LoginActivity : BaseActivity() {
     private fun showCreateDialog() {
         val builder = AlertDialog.Builder(this@LoginActivity)
         val walletLengthList = listOf(getString(R.string.create_word_option_1), getString(R.string.create_word_option_2)).toTypedArray()
-        builder.setTitle("Create Wallet")
+        builder.setTitle(getString(R.string.create_wallet))
                 .setItems(walletLengthList) { _, which ->
                     // The 'which' argument contains the index position
                     // of the selected item
@@ -59,7 +59,7 @@ class LoginActivity : BaseActivity() {
     private fun showRecoverDialog() {
         val builder = AlertDialog.Builder(this@LoginActivity)
         val walletLengthList = listOf(getString(R.string.recover_from_phrase), getString(R.string.recover_from_seed)).toTypedArray()
-        builder.setTitle("Recover Wallet")
+        builder.setTitle(getString(R.string.recover_wallet))
                 .setItems(walletLengthList) { _, which ->
                     // The 'which' argument contains the index position
                     // of the selected item

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/LoginActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/LoginActivity.kt
@@ -36,7 +36,7 @@ class LoginActivity : BaseActivity() {
 
     private fun showCreateDialog() {
         val builder = AlertDialog.Builder(this@LoginActivity)
-        val walletLengthList = listOf("Use a 12 word recovery phrase", "Use a 24 word recovery phrase").toTypedArray()
+        val walletLengthList = listOf(getString(R.string.create_word_option_1), getString(R.string.create_word_option_2)).toTypedArray()
         builder.setTitle("Create Wallet")
                 .setItems(walletLengthList) { _, which ->
                     // The 'which' argument contains the index position
@@ -58,7 +58,7 @@ class LoginActivity : BaseActivity() {
 
     private fun showRecoverDialog() {
         val builder = AlertDialog.Builder(this@LoginActivity)
-        val walletLengthList = listOf("Recover from phrase", "Recover from secret key").toTypedArray()
+        val walletLengthList = listOf(getString(R.string.recover_from_phrase), getString(R.string.recover_from_seed)).toTypedArray()
         builder.setTitle("Recover Wallet")
                 .setItems(walletLengthList) { _, which ->
                     // The 'which' argument contains the index position

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/LoginActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/LoginActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AlertDialog
 import blockeq.com.stellarwallet.R
-import blockeq.com.stellarwallet.WalletApplication
 import kotlinx.android.synthetic.main.activity_login.*
 
 
@@ -27,15 +26,15 @@ class LoginActivity : BaseActivity() {
     override fun setupUI() {
 
         createWalletButton.setOnClickListener {
-            showDialog()
+            showCreateDialog()
         }
 
         recoverWalletButton.setOnClickListener {
-            startActivity(Intent(this, RecoverWalletActivity::class.java))
+            showRecoverDialog()
         }
     }
 
-    private fun showDialog() {
+    private fun showCreateDialog() {
         val builder = AlertDialog.Builder(this@LoginActivity)
         val walletLengthList = listOf("Use a 12 word recovery phrase", "Use a 24 word recovery phrase").toTypedArray()
         builder.setTitle("Create Wallet")
@@ -57,6 +56,23 @@ class LoginActivity : BaseActivity() {
         dialog.show()
     }
 
+    private fun showRecoverDialog() {
+        val builder = AlertDialog.Builder(this@LoginActivity)
+        val walletLengthList = listOf("Recover from phrase", "Recover from secret key").toTypedArray()
+        builder.setTitle("Recover Wallet")
+                .setItems(walletLengthList) { _, which ->
+                    // The 'which' argument contains the index position
+                    // of the selected item
+
+                    val isPhraseRecovery = (which == 0)
+
+                    val intent = Intent(this, RecoverWalletActivity::class.java)
+                    intent.putExtra("isPhraseRecovery", isPhraseRecovery)
+                    startActivity(intent)
+                }
+        val dialog = builder.create()
+        dialog.show()
+    }
 
     //endregion
 }

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
@@ -188,7 +188,7 @@ class PinActivity : BaseActivity(), PinLockListener {
 
     //region Encryption and Decryption
     private fun getKeyPair(string : String) : KeyPair {
-        return if (pinViewState!!.type == PinType.CREATE) {
+        return if (WalletApplication.localStore!!.isRecoveryPhrase) {
             Wallet.createKeyPair(string.toCharArray(), null, Constants.USER_INDEX)
         } else {
             KeyPair.fromSecretSeed(string)

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
@@ -58,7 +58,7 @@ class PinActivity : BaseActivity(), PinLockListener {
         val handler = Handler()
         val runnableCode = Runnable {
             when (pinViewState!!.type) {
-                PinType.CREATE -> {
+                PinType.CREATE_WITH_PHRASE -> {
                     when {
                         needConfirm -> {
                             PIN = pin

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
@@ -18,6 +18,7 @@ import blockeq.com.stellarwallet.models.PinViewState
 import com.andrognito.pinlockview.PinLockListener
 import com.soneso.stellarmnemonics.Wallet
 import kotlinx.android.synthetic.main.activity_pin.*
+import org.stellar.sdk.KeyPair
 
 class PinActivity : BaseActivity(), PinLockListener {
 
@@ -58,7 +59,7 @@ class PinActivity : BaseActivity(), PinLockListener {
         val handler = Handler()
         val runnableCode = Runnable {
             when (pinViewState!!.type) {
-                PinType.CREATE_WITH_PHRASE -> {
+                PinType.CREATE -> {
                     when {
                         needConfirm -> {
                             PIN = pin
@@ -81,7 +82,8 @@ class PinActivity : BaseActivity(), PinLockListener {
 
                             WalletApplication.localStore!!.encryptedPhrase = encryptedData
 
-                            val keyPair = Wallet.createKeyPair(pinViewState!!.phrase.toCharArray(), null, Constants.USER_INDEX)
+                            val keyPair = getKeyPair(pinViewState!!.phrase)
+
                             WalletApplication.localStore!!.publicKey = keyPair.accountId
 
                             launchWallet()
@@ -101,7 +103,7 @@ class PinActivity : BaseActivity(), PinLockListener {
                                 launchWallet()
                             }
                             pinViewState!!.type == PinType.CHECK -> {
-                                val keyPair = Wallet.createKeyPair(decryptedData.toCharArray(), null, Constants.USER_INDEX)
+                                val keyPair = getKeyPair(decryptedData)
                                 val intent = Intent()
                                 intent.putExtra(KEY_SECRET_SEED, keyPair.secretSeed)
                                 setResult(Activity.RESULT_OK, intent)
@@ -118,7 +120,7 @@ class PinActivity : BaseActivity(), PinLockListener {
                             }
 
                             pinViewState!!.type == PinType.VIEW_SEED -> {
-                                val keyPair = Wallet.createKeyPair(decryptedData.toCharArray(), null, Constants.USER_INDEX)
+                                val keyPair = getKeyPair(decryptedData)
                                 val secretSeed = keyPair.secretSeed.joinToString("")
                                 val intent = Intent(this, ViewSecretSeedActivity::class.java)
 
@@ -138,8 +140,7 @@ class PinActivity : BaseActivity(), PinLockListener {
 
     //region User Interface
 
-    override fun onPinChange(pinLength: Int, intermediatePin: String?) {
-    }
+    override fun onPinChange(pinLength: Int, intermediatePin: String?) {}
 
     private fun onIncorrectPin() {
         showWrongPinDots(true)
@@ -182,12 +183,18 @@ class PinActivity : BaseActivity(), PinLockListener {
         return bundle.getParcelable(PinFlowController.OBJECT)
     }
 
-
-
     //endregion
 
 
     //region Encryption and Decryption
+    private fun getKeyPair(string : String) : KeyPair {
+        return if (pinViewState!!.type == PinType.CREATE) {
+            Wallet.createKeyPair(string.toCharArray(), null, Constants.USER_INDEX)
+        } else {
+            KeyPair.fromSecretSeed(string)
+        }
+    }
+
     private fun getEncryptedPhrase(pinType: PinType) : String {
         return if (pinType == PinType.CHECK || pinType == PinType.LOGIN) {
             WalletApplication.localStore!!.encryptedPhrase!!

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/RecoverWalletActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/RecoverWalletActivity.kt
@@ -53,7 +53,7 @@ class RecoverWalletActivity : BaseActivity() {
             val wordCount = getWordCount(recoveryString)
             if (isRecoveryPhrase) {
                 if (wordCount == 12 || wordCount == 24) {
-                    launchPINView(PinType.CREATE,
+                    launchPINView(PinType.CREATE_WITH_PHRASE,
                             getString(R.string.please_create_a_pin),
                             recoveryString,
                             false)
@@ -62,7 +62,10 @@ class RecoverWalletActivity : BaseActivity() {
                 }
             } else {
                 if (wordCount == 1 && recoveryString[0] == 'S') {
-
+                    launchPINView(PinType.CREATE_WITH_SECRET,
+                            getString(R.string.please_create_a_pin),
+                            recoveryString,
+                            false)
                 } else {
                     showErrorMessage()
                 }

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/RecoverWalletActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/RecoverWalletActivity.kt
@@ -74,7 +74,7 @@ class RecoverWalletActivity : BaseActivity() {
         setSupportActionBar(findViewById(R.id.recoverToolbar))
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
 
-        recoverToolbar.title = if (isRecoveryPhrase) {
+        supportActionBar!!.title = if (isRecoveryPhrase) {
             getString(R.string.enter_phrase)
         } else {
             getString(R.string.enter_secret_key)

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/RecoverWalletActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/RecoverWalletActivity.kt
@@ -2,6 +2,7 @@ package blockeq.com.stellarwallet.activities
 
 import android.content.Intent
 import android.os.Bundle
+import android.text.method.DigitsKeyListener
 import android.view.MenuItem
 import android.view.View
 import blockeq.com.stellarwallet.R
@@ -12,10 +13,13 @@ import kotlinx.android.synthetic.main.activity_recover_wallet.*
 
 class RecoverWalletActivity : BaseActivity() {
 
+    var isRecoveryPhrase = true
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_recover_wallet)
 
+        isRecoveryPhrase = intent.getBooleanExtra("isPhraseRecovery", true)
         setupUI()
     }
 
@@ -40,15 +44,28 @@ class RecoverWalletActivity : BaseActivity() {
     override fun setupUI() {
         setupToolbar()
 
+        if (!isRecoveryPhrase) {
+            phraseEditText.keyListener = DigitsKeyListener.getInstance(getString(R.string.stellar_address_alphabet))
+        }
+
         nextButton.setOnClickListener {
-            val wordCount = getWordCount(getMnemonicString())
-            if (wordCount == 12 || wordCount == 24) {
-                launchPINView(PinType.CREATE,
-                        getString(R.string.please_create_a_pin),
-                        getMnemonicString(),
-                        false)
+            val recoveryString = getMnemonicString()
+            val wordCount = getWordCount(recoveryString)
+            if (isRecoveryPhrase) {
+                if (wordCount == 12 || wordCount == 24) {
+                    launchPINView(PinType.CREATE,
+                            getString(R.string.please_create_a_pin),
+                            recoveryString,
+                            false)
+                } else {
+                    showErrorMessage()
+                }
             } else {
-                showErrorMessage()
+                if (wordCount == 1 && recoveryString[0] == 'S') {
+
+                } else {
+                    showErrorMessage()
+                }
             }
         }
     }
@@ -56,6 +73,12 @@ class RecoverWalletActivity : BaseActivity() {
     private fun setupToolbar() {
         setSupportActionBar(findViewById(R.id.recoverToolbar))
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+
+        recoverToolbar.title = if (isRecoveryPhrase) {
+            getString(R.string.enter_phrase)
+        } else {
+            getString(R.string.enter_secret_key)
+        }
     }
 
     private fun showErrorMessage() {

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/ShowMnemonicActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/ShowMnemonicActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.support.v7.widget.Toolbar
 import android.view.View
 import blockeq.com.stellarwallet.R
+import blockeq.com.stellarwallet.WalletApplication
 import blockeq.com.stellarwallet.activities.PinActivity.Companion.PIN_REQUEST_CODE
 import blockeq.com.stellarwallet.models.PinType
 import com.soneso.stellarmnemonics.Wallet
@@ -48,6 +49,10 @@ class ShowMnemonicActivity : BaseActivity(), View.OnClickListener {
     override fun setupUI() {
         if (isDisplayPhraseOnly) {
             confirmButton.visibility = View.GONE
+            if (!WalletApplication.localStore!!.isRecoveryPhrase) {
+                warningPhraseTextView.text = getString(R.string.no_mnemonic_set)
+                mnemonicView.visibility = View.GONE
+            }
         }
         setupActionBar()
         setupMnemonicView()
@@ -76,8 +81,7 @@ class ShowMnemonicActivity : BaseActivity(), View.OnClickListener {
     //region Helper functions
     private fun getMnemonic(): ArrayList<String> {
         if (isDisplayPhraseOnly) {
-            val words = mnemonicString!!.split(" ".toRegex()).dropLastWhile { it.isEmpty() } as ArrayList
-            return words
+            return ArrayList(mnemonicString!!.split(" ".toRegex()).dropLastWhile { it.isEmpty() })
         } else {
             val mnemonic = if (intent.getIntExtra("walletLength", 12) == 12) {
                 Wallet.generate12WordMnemonic()

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/ShowMnemonicActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/ShowMnemonicActivity.kt
@@ -41,7 +41,7 @@ class ShowMnemonicActivity : BaseActivity(), View.OnClickListener {
     override fun onClick(v: View?) {
         val itemId = v!!.id
         when (itemId) {
-            R.id.confirmButton -> launchPINView(PinType.CREATE_WITH_PHRASE, getString(R.string.please_create_a_pin), mnemonicString!!, false)
+            R.id.confirmButton -> launchPINView(PinType.CREATE, getString(R.string.please_create_a_pin), mnemonicString!!, false)
         }
     }
 

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/ShowMnemonicActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/ShowMnemonicActivity.kt
@@ -41,7 +41,7 @@ class ShowMnemonicActivity : BaseActivity(), View.OnClickListener {
     override fun onClick(v: View?) {
         val itemId = v!!.id
         when (itemId) {
-            R.id.confirmButton -> launchPINView(PinType.CREATE, getString(R.string.please_create_a_pin), mnemonicString!!, false)
+            R.id.confirmButton -> launchPINView(PinType.CREATE_WITH_PHRASE, getString(R.string.please_create_a_pin), mnemonicString!!, false)
         }
     }
 

--- a/app/src/main/java/blockeq/com/stellarwallet/helpers/LocalStore.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/helpers/LocalStore.kt
@@ -15,11 +15,11 @@ class LocalStore(private val sharedPreferences: SharedPreferences, private val g
         set(viewState) = set<PinViewState>(KEY_PIN_DATA, viewState!!)
 
     var encryptedPhrase: String?
-        get() = get(KEY_ENCRYPTED_PHRASE)
+        get() = getString(KEY_ENCRYPTED_PHRASE)
         set(encryptedPhrase) = set(KEY_ENCRYPTED_PHRASE, encryptedPhrase)
 
     var publicKey: String?
-        get() = get(KEY_STELLAR_ACCOUNT_PUBLIC_KEY)
+        get() = getString(KEY_STELLAR_ACCOUNT_PUBLIC_KEY)
         set(publicKey) = set(KEY_STELLAR_ACCOUNT_PUBLIC_KEY, publicKey)
 
     var balances: Array<AccountResponse.Balance>?
@@ -27,8 +27,12 @@ class LocalStore(private val sharedPreferences: SharedPreferences, private val g
         set(balances) = set(KEY_STELLAR_BALANCES_KEY, balances)
 
     var availableBalance: String?
-        get() = get(KEY_STELLAR_AVAILABLE_BALANCE_KEY)
+        get() = getString(KEY_STELLAR_AVAILABLE_BALANCE_KEY)
         set(availableBalance) = set(KEY_STELLAR_AVAILABLE_BALANCE_KEY, availableBalance)
+
+    var isRecoveryPhrase : Boolean
+        get() = getBoolean(KEY_IS_RECOVERY_PHRASE)
+        set(isRecoveryPhrase) = set(KEY_IS_RECOVERY_PHRASE, isRecoveryPhrase)
 
     init {
         balances = arrayOf()
@@ -41,10 +45,15 @@ class LocalStore(private val sharedPreferences: SharedPreferences, private val g
         const val KEY_STELLAR_ACCOUNT_PUBLIC_KEY = "kStellarAccountPublicKey"
         const val KEY_STELLAR_BALANCES_KEY = "kStellarBalancesKey"
         const val KEY_STELLAR_AVAILABLE_BALANCE_KEY = "kAvailableBalanceKey"
+        const val KEY_IS_RECOVERY_PHRASE = "kIsRecoveryPhrase"
     }
 
     private operator fun set(key: String, value: String?) {
         sharedPreferences.edit().putString(key, value).apply()
+    }
+
+    private operator fun set(key: String, value: Boolean) {
+        sharedPreferences.edit().putBoolean(key, value).apply()
     }
 
     private operator fun <T> set(key: String, obj: T) {
@@ -52,12 +61,16 @@ class LocalStore(private val sharedPreferences: SharedPreferences, private val g
         set(key, json)
     }
 
-    private operator fun get(key: String): String? {
+    private fun getString(key: String): String? {
         return sharedPreferences.getString(key, "")
     }
 
+    private fun getBoolean(key: String): Boolean {
+        return sharedPreferences.getBoolean(key, true)
+    }
+
     private operator fun <T> get(key: String, klass: Class<T>): T? {
-        val json = get(key) ?: return null
+        val json = getString(key) ?: return null
         return try {
             gson.fromJson(json, klass)
         } catch (e: JsonSyntaxException) {
@@ -73,6 +86,7 @@ class LocalStore(private val sharedPreferences: SharedPreferences, private val g
         editor.remove(KEY_STELLAR_ACCOUNT_PUBLIC_KEY)
         editor.remove(KEY_STELLAR_BALANCES_KEY)
         editor.remove(KEY_STELLAR_AVAILABLE_BALANCE_KEY)
+        editor.remove(KEY_IS_RECOVERY_PHRASE)
         editor.apply()
 
         balances = arrayOf()

--- a/app/src/main/java/blockeq/com/stellarwallet/models/PinViewState.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/models/PinViewState.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 enum class PinType {
-    CREATE_WITH_PHRASE, CREATE_WITH_SECRET, LOGIN, VIEW_PHRASE, VIEW_SEED, CLEAR_WALLET, CHECK
+    CREATE, LOGIN, VIEW_PHRASE, VIEW_SEED, CLEAR_WALLET, CHECK
 }
 
 @Parcelize

--- a/app/src/main/java/blockeq/com/stellarwallet/models/PinViewState.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/models/PinViewState.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 enum class PinType {
-    CREATE, LOGIN, VIEW_PHRASE, VIEW_SEED, CLEAR_WALLET, CHECK
+    CREATE_WITH_PHRASE, CREATE_WITH_SECRET, LOGIN, VIEW_PHRASE, VIEW_SEED, CLEAR_WALLET, CHECK
 }
 
 @Parcelize

--- a/app/src/main/res/layout/activity_recover_wallet.xml
+++ b/app/src/main/res/layout/activity_recover_wallet.xml
@@ -21,7 +21,7 @@
         android:layout_below="@+id/recoverToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/invalid_word_count"
+        android:text="@string/invalid_input_for_phrase"
         style="@style/RegularText"
         android:gravity="center"
         android:textColor="@color/terracotta"
@@ -41,6 +41,18 @@
         android:textSize="@dimen/text_size_medium"
         android:gravity="top"/>
 
+    <EditText
+        android:id="@+id/secretKeyEditText"
+        android:layout_below="@id/invalidPhraseTextView"
+        android:layout_above="@id/nextButton"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:digits="@string/stellar_address_alphabet"
+        style="@style/RegularText"
+        android:padding="@dimen/activity_vertical_margin"
+        android:background="@android:color/transparent"
+        android:textSize="@dimen/text_size_medium"
+        android:gravity="top"/>
 
     <Button
         android:id="@+id/nextButton"

--- a/app/src/main/res/layout/activity_recover_wallet.xml
+++ b/app/src/main/res/layout/activity_recover_wallet.xml
@@ -12,7 +12,6 @@
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:elevation="4dp"
-        app:title="@string/enter_phrase"
         app:titleTextColor="@color/colorPrimaryDark"
         android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="create_new_wallet">Create new wallet</string>
     <string name="recover_wallet">Recover wallet</string>
     <string name="phrase_warning">Please write down and safely store this phrase. It\'s the ONLY WAY to retrieve your wallet.</string>
+    <string name="no_mnemonic_set">Your wallet was recovered using a secret key and does not use a mnemonic.</string>
     <string name="confirm_written">I have written it down</string>
     <string name="enter_phrase">Enter Phrase</string>
     <string name="enter_secret_key">Enter Secret Key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,8 @@
     <string name="enter_phrase">Enter Phrase</string>
     <string name="enter_secret_key">Enter Secret Key</string>
     <string name="secret_phrase">Secret Phrase</string>
-    <string name="invalid_word_count">Invalid number of words (must be 12 or 24).</string>
+    <string name="invalid_input_for_phrase">Invalid number of words (must be 12 or 24).</string>
+    <string name="invalid_input_for_secret">Invalid secret key.</string>
 
     <!--Settings Fragment-->
     <string name="recovery">Recovery</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,10 @@
     <string name="secret_phrase">Secret Phrase</string>
     <string name="invalid_input_for_phrase">Invalid number of words (must be 12 or 24).</string>
     <string name="invalid_input_for_secret">Invalid secret key.</string>
+    <string name="create_word_option_1">Use a 12 word recovery phrase</string>
+    <string name="create_word_option_2">Use a 24 word recovery phrase</string>
+    <string name="recover_from_phrase">Recover from phrase</string>
+    <string name="recover_from_seed">Recover from secret key</string>
 
     <!--Settings Fragment-->
     <string name="recovery">Recovery</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="phrase_warning">Please write down and safely store this phrase. It\'s the ONLY WAY to retrieve your wallet.</string>
     <string name="confirm_written">I have written it down</string>
     <string name="enter_phrase">Enter Phrase</string>
+    <string name="enter_secret_key">Enter Secret Key</string>
     <string name="secret_phrase">Secret Phrase</string>
     <string name="invalid_word_count">Invalid number of words (must be 12 or 24).</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
 
     <!-- Login Strings -->
     <string name="create_new_wallet">Create new wallet</string>
+    <string name="create_wallet">Create Wallet</string>
     <string name="recover_wallet">Recover wallet</string>
     <string name="phrase_warning">Please write down and safely store this phrase. It\'s the ONLY WAY to retrieve your wallet.</string>
     <string name="no_mnemonic_set">Your wallet was recovered using a secret key and does not use a mnemonic.</string>


### PR DESCRIPTION
## Priority
Urgent 👍 

## Description
* Enables user to import a wallet with their secret seed
* Refactored PIN Activity to enable generating keypair via phrase or seed based on which is used
* Added a local store property for `isRecoveryPhrase` to indicate whether a phrase or seed is used
* Refactored `get` method names in local store to indicate getString or getBoolean (can't overload it :( )

## Screenshot

(Highlights UI changes)

When showing phrase from a secret seed generated account

![screenshot_20181015-145323](https://user-images.githubusercontent.com/2541326/46971647-90e82f80-d08a-11e8-8ba0-1dacc844827a.png)

Added new dialog

![screenshot_20181015-145342](https://user-images.githubusercontent.com/2541326/46971645-8f1e6c00-d08a-11e8-8037-671cdd24ab14.png)
