### PR TITLE
Fix two crashes to Android, NumberFormatException and ClassCastExcept

### DIFF
--- a/app/src/main/java/blockeq/com/stellarwallet/helpers/Constants.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/helpers/Constants.kt
@@ -12,6 +12,7 @@ class Constants {
         const val BASE_RESERVE = 0.5
 
         const val SERVER_ERROR_NOT_FOUND = 404
+        const val UNKNOWN_ERROR = 520
 
         const val LUMENS_ASSET_TYPE = "native"
         const val LUMENS_ASSET_CODE = "XLM"

--- a/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
@@ -34,7 +34,11 @@ class Horizon {
 
                 } catch (error : Exception) {
                     Log.d(TAG, error.message.toString())
-                    listener.onError((error as ErrorResponse))
+                    if (error is ErrorResponse) {
+                        listener.onError(error)
+                    } else {
+                        listener.onError(ErrorResponse(0, ""))
+                    }
                 }
 
                 return account

--- a/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/services/networking/Horizon.kt
@@ -37,7 +37,7 @@ class Horizon {
                     if (error is ErrorResponse) {
                         listener.onError(error)
                     } else {
-                        listener.onError(ErrorResponse(0, ""))
+                        listener.onError(ErrorResponse(Constants.UNKNOWN_ERROR, error.message))
                     }
                 }
 

--- a/app/src/main/java/blockeq/com/stellarwallet/utils/StringFormat.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/utils/StringFormat.kt
@@ -15,7 +15,7 @@ class StringFormat {
         }
 
         fun truncateDecimalPlaces(string: String?): String {
-            if (string == null) return ""
+            if (string == null) return Constants.DEFAULT_ACCOUNT_BALANCE
             return String.format("%.4f", string.toDouble())
         }
 

--- a/app/src/main/java/blockeq/com/stellarwallet/utils/StringFormat.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/utils/StringFormat.kt
@@ -16,7 +16,7 @@ class StringFormat {
 
         fun truncateDecimalPlaces(string: String?): String {
             if (string == null) return Constants.DEFAULT_ACCOUNT_BALANCE
-            return String.format("%.4f", string.toDouble())
+            return String.format(Locale.ENGLISH, "%.4f", string.toDouble())
         }
 
         /**


### PR DESCRIPTION
## Priority
Urgent

## Description
* Fixes the NumberFormatException caused at `AccountUtils.kt:50` from a parse to Double error, likely from an empty string, returned from StringFormat.truncateDecimalPlaces()
* Check to see if the error response cast is safe to cast before casting it
