### PR TITLE
[UninitializedPropertyAccessException] disabling trading tab and releasing 1.0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Trade support.
 
+## [1.0.4.1] - 2018-11-17
+### Fixed
+- Disabling and hiding the navigation item: `trading`, the feature was not ready.
+
 ## [1.0.4] - 2018-11-16
 ### Added
 - Start using changelog

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "blockeq.com.stellarwallet"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 15
-        versionName "1.0.4"
+        versionCode 16
+        versionName "1.0.4.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/WalletActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/WalletActivity.kt
@@ -34,10 +34,10 @@ class WalletActivity : BaseActivity() {
                 val walletFragment = WalletFragment.newInstance()
                 openFragment(walletFragment)
             }
-            R.id.nav_trading -> {
-                val tradingFragment = TradingFragment.newInstance()
-                openFragment(tradingFragment)
-            }
+//            R.id.nav_trading -> {
+//                val tradingFragment = TradingFragment.newInstance()
+//                openFragment(tradingFragment)
+//            }
             R.id.nav_settings -> {
                 val settingsFragment = SettingsFragment.newInstance()
                 openFragment(settingsFragment)

--- a/app/src/main/res/menu/navigation.xml
+++ b/app/src/main/res/menu/navigation.xml
@@ -6,10 +6,10 @@
         android:icon="@drawable/ic_wallet"
         android:title="@string/nav_wallet"/>
 
-    <item
-        android:id="@+id/nav_trading"
-        android:icon="@drawable/ic_trading"
-        android:title="@string/nav_trading"/>
+    <!--<item-->
+        <!--android:id="@+id/nav_trading"-->
+        <!--android:icon="@drawable/ic_trading"-->
+        <!--android:title="@string/nav_trading"/>-->
 
     <item
         android:id="@+id/nav_settings"


### PR DESCRIPTION
## Priority
High

## Description
* In the release 1.0.4 the tab trading is visible and clickable. It results in a crash. The 40% rollout was put on halt once this issue was discovered. The release 1.0.4.1 will hide the button like before.
15 crashes were reported.

https://play.google.com/apps/publish/?account=6549307174189725652#AndroidMetricsErrorsPlace:p=blockeq.com.stellarwallet&appid=4976065261645839663&appVersion=PRODUCTION&clusterName=apps/blockeq.com.stellarwallet/clusters/26d4842f&detailsAppVersion=PRODUCTION&detailsSpan=7

## Notes
kotlin.UninitializedPropertyAccessException: 
  at blockeq.com.stellarwallet.fragments.tabs.OrderBookTabFragment.updateTradingCurrencies (OrderBookTabFragment.kt:98)
  at blockeq.com.stellarwallet.fragments.TradingFragment.onCurrencyChange (TradingFragment.kt:19)
  at blockeq.com.stellarwallet.fragments.tabs.TradeTabFragment$setupListeners$2.onItemSelected (TradeTabFragment.kt:83)
  at android.widget.AdapterView.fireOnSelected (AdapterView.java:944)
  at android.widget.AdapterView.dispatchOnItemSelected (AdapterView.java:933)
  at android.widget.AdapterView.-wrap1 (Unknown Source)
  at android.widget.AdapterView$SelectionNotifier.run (AdapterView.java:898)
  at android.os.Handler.handleCallback (Handler.java:789)
  at android.os.Handler.dispatchMessage (Handler.java:98)
  at android.os.Looper.loop (Looper.java:251)
  at android.app.ActivityThread.main (ActivityThread.java:6572)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:240)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:767)