### PR TITLE
Remove passphrase flag

### DIFF
--- a/app/src/androidTest/java/blockeq/com/stellarwallet/utils/AccountUtilsTest.java
+++ b/app/src/androidTest/java/blockeq/com/stellarwallet/utils/AccountUtilsTest.java
@@ -104,7 +104,11 @@ public class AccountUtilsTest {
         assertNotNull(keyPair);
 
         String decryptedPhrase = AccountUtils.Companion.getDecryptedString(phrase, keyPair);
-        String decryptedPassphrase = AccountUtils.Companion.getDecryptedPassphrase(WalletApplication.localStore.getEncryptedPassphrase(), keyPair);
+        String encryptedPassphrase = WalletApplication.localStore.getEncryptedPassphrase();
+        String decryptedPassphrase = null;
+        if (encryptedPassphrase != null) {
+            decryptedPassphrase = AccountUtils.Companion.getDecryptedString(encryptedPassphrase, keyPair);
+        }
 
         assertEquals(mnemonic12, decryptedPhrase);
         assertEquals(passPhrase, decryptedPassphrase);
@@ -123,7 +127,11 @@ public class AccountUtilsTest {
         assertNotNull(keyPair);
 
         String decryptedPhrase = AccountUtils.Companion.getDecryptedString(phrase, keyPair);
-        String decryptedPassphrase = AccountUtils.Companion.getDecryptedPassphrase(WalletApplication.localStore.getEncryptedPassphrase(), keyPair);
+        String encryptedPassphrase = WalletApplication.localStore.getEncryptedPassphrase();
+        String decryptedPassphrase = null;
+        if (encryptedPassphrase != null) {
+            decryptedPassphrase = AccountUtils.Companion.getDecryptedString(encryptedPassphrase, keyPair);
+        }
 
         assertEquals(mnemonic12, decryptedPhrase);
         assertEquals(passphrase, decryptedPassphrase);
@@ -141,7 +149,11 @@ public class AccountUtilsTest {
         assertNotNull(keyPair);
 
         String decryptedPhrase = AccountUtils.Companion.getDecryptedString(phrase, keyPair);
-        String decryptedPassphrase = AccountUtils.Companion.getDecryptedPassphrase(WalletApplication.localStore.getEncryptedPassphrase(), keyPair);
+        String encryptedPassphrase = WalletApplication.localStore.getEncryptedPassphrase();
+        String decryptedPassphrase = null;
+        if (encryptedPassphrase != null) {
+            decryptedPassphrase = AccountUtils.Companion.getDecryptedString(encryptedPassphrase, keyPair);
+        }
 
         assertEquals(mnemonic24, decryptedPhrase);
         assertEquals(passphrase, decryptedPassphrase);
@@ -177,7 +189,11 @@ public class AccountUtilsTest {
         assertNotNull(keyPair);
 
         String decryptedPhrase = AccountUtils.Companion.getDecryptedString(encryptedPhrase, keyPair);
-        String decryptedPassphrase = AccountUtils.Companion.getDecryptedPassphrase(WalletApplication.localStore.getEncryptedPassphrase(), keyPair);
+        String encryptedPassphrase = WalletApplication.localStore.getEncryptedPassphrase();
+        String decryptedPassphrase = null;
+        if (encryptedPassphrase != null) {
+            decryptedPassphrase = AccountUtils.Companion.getDecryptedString(encryptedPassphrase, keyPair);
+        }
 
         if (AccountUtils.Companion.isOldWalletWithPassphrase()) {
             Pair<String, String> decryptedPair = AccountUtils.Companion.getOldDecryptedPair(encryptedPhrase, keyPair.getPrivate());

--- a/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/activities/PinActivity.kt
@@ -89,7 +89,10 @@ class PinActivity : BaseActivity(), PinLockListener {
 
                     if (masterKey != null) {
                         var decryptedPhrase = AccountUtils.getDecryptedString(encryptedPhrase, masterKey)
-                        var decryptedPassphrase = AccountUtils.getDecryptedPassphrase(encryptedPassphrase, masterKey)
+                        var decryptedPassphrase : String? = null
+                        if (encryptedPassphrase != null) {
+                            decryptedPassphrase = AccountUtils.getDecryptedString(encryptedPassphrase, masterKey)
+                        }
 
                         // TODO: Remove for new app, this is purely passphrase migration code
                         // backwards compatible for wallets 1.0.3 or older

--- a/app/src/main/java/blockeq/com/stellarwallet/helpers/LocalStore.kt
+++ b/app/src/main/java/blockeq/com/stellarwallet/helpers/LocalStore.kt
@@ -36,6 +36,7 @@ class LocalStore(private val sharedPreferences: SharedPreferences, private val g
         get() = getBoolean(KEY_PIN_SETTINGS_SEND)
         set(showPinOnSend) = set(KEY_PIN_SETTINGS_SEND, showPinOnSend)
 
+    @Deprecated("TODO: Remove this method in new app")
     var isPassphraseUsed : Boolean
         get() = getBoolean(KEY_IS_PASSPHRASE_USED)
         set(isPassphraseUsed) = set(KEY_IS_PASSPHRASE_USED, isPassphraseUsed)


### PR DESCRIPTION
## Priority
High

## Description
* Add a check for isPassphrase flag for devices in a migration/flag state issue where isPassphrase is true when there is no passphrase
* Removed usage of the `isPassphraseUsed` flag in non-deprecated functions