### PR TITLE
Feature/moving logic from pin activity to wallet manager activity

### DIFF
--- a/app/src/androidTest/java/com/blockeq/stellarwallet/ViewSecretSeedPage.kt
+++ b/app/src/androidTest/java/com/blockeq/stellarwallet/ViewSecretSeedPage.kt
@@ -8,7 +8,7 @@ import android.support.test.espresso.assertion.ViewAssertions
 
 object ViewSecretSeedPage : BasePage() {
     override fun onPageLoaded(): ViewSecretSeedPage {
-        onView(ViewMatchers.withId(R.id.toolBar))
+        onView(ViewMatchers.withId(R.id.secretSeedTextView))
         return this
     }
 

--- a/app/src/androidTest/java/com/blockeq/stellarwallet/WalletCreationTest.kt
+++ b/app/src/androidTest/java/com/blockeq/stellarwallet/WalletCreationTest.kt
@@ -26,7 +26,7 @@ class WalletCreationTest {
 
     @Test
     fun testCreateWalletOption12Words() {
-        LaunchPage.onPageLoaded().createWallet(MnemonicType.WORD_12, pin)
+        createWallet(MnemonicType.WORD_12, pin)
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,6 +94,13 @@
         <activity android:name=".activities.DebugPreferenceActivity"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme"/>
+
+        <activity android:name=".activities.WalletManagerActivity"
+            android:screenOrientation="portrait"/>
+
+        <activity android:name=".activities.SimplePinActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/AppTheme"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/BaseActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/BaseActivity.kt
@@ -1,8 +1,10 @@
 package com.blockeq.stellarwallet.activities
 
+import android.app.Activity
 import android.content.Intent
 import android.support.v7.app.AppCompatActivity
 import com.blockeq.stellarwallet.WalletApplication
+import com.blockeq.stellarwallet.activities.PinActivity.Companion.PIN_REQUEST_CODE
 import com.blockeq.stellarwallet.flowcontrollers.PinFlowController
 import com.blockeq.stellarwallet.models.PinType
 import com.blockeq.stellarwallet.models.PinViewState
@@ -10,6 +12,8 @@ import com.blockeq.stellarwallet.utils.AccountUtils
 import com.blockeq.stellarwallet.utils.DebugPreferencesHelper
 
 abstract class BaseActivity : AppCompatActivity() {
+    private val VERIFY_PIN_REQUEST : Int = 0x01
+
     override fun onResume() {
         super.onResume()
 
@@ -19,7 +23,7 @@ abstract class BaseActivity : AppCompatActivity() {
 
             if (!WalletApplication.localStore.encryptedPhrase.isNullOrEmpty()
                     && !WalletApplication.localStore.stellarAccountId.isNullOrEmpty()) {
-                launchPINView(PinType.LOGIN, "", "", null)
+                startActivityForResult(WalletManagerActivity.verifyPin(this), VERIFY_PIN_REQUEST)
             } else {
                 AccountUtils.wipe(this)
             }
@@ -40,11 +44,9 @@ abstract class BaseActivity : AppCompatActivity() {
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == PinActivity.PIN_REQUEST_CODE) {
-            if (resultCode == PinActivity.SUCCESS_PIN && data != null) {
-                val pin = data.getStringExtra(PinActivity.KEY_PIN)
-
-                WalletApplication.userSession.pin = pin
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == VERIFY_PIN_REQUEST) {
+            if (resultCode == Activity.RESULT_OK) {
                 launchWallet()
             }
         }

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/LaunchActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/LaunchActivity.kt
@@ -1,6 +1,5 @@
 package com.blockeq.stellarwallet.activities
 
-import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AlertDialog
 import com.blockeq.stellarwallet.R
@@ -58,9 +57,7 @@ class LaunchActivity : BaseActivity() {
 
                     val isPhraseRecovery = (which == 0)
 
-                    val intent = Intent(this, RecoverWalletActivity::class.java)
-                    intent.putExtra("isPhraseRecovery", isPhraseRecovery)
-                    startActivity(intent)
+                    startActivity(RecoverWalletActivity.newInstance(this, isPhraseRecovery))
                 }
         val dialog = builder.create()
         dialog.show()

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/MnemonicActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/MnemonicActivity.kt
@@ -1,5 +1,6 @@
 package com.blockeq.stellarwallet.activities
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -8,17 +9,15 @@ import android.view.View
 import android.widget.ImageView
 import com.blockeq.stellarwallet.R
 import com.blockeq.stellarwallet.WalletApplication
-import com.blockeq.stellarwallet.activities.PinActivity.Companion.PIN_REQUEST_CODE
 import com.blockeq.stellarwallet.helpers.PassphraseDialogHelper
 import com.blockeq.stellarwallet.models.MnemonicType
-import com.blockeq.stellarwallet.models.PinType
-import com.blockeq.stellarwallet.utils.AccountUtils
 import com.google.zxing.BarcodeFormat
 import com.journeyapps.barcodescanner.BarcodeEncoder
 import com.soneso.stellarmnemonics.Wallet
 import kotlinx.android.synthetic.main.activity_mnemonic.*
 
 class MnemonicActivity : BaseActivity(), View.OnClickListener {
+    private val CREATE_WALLET_REQUEST = 0x01
 
     companion object {
         private const val MNEMONIC_PHRASE = "MNEMONIC_PHRASE"
@@ -52,12 +51,8 @@ class MnemonicActivity : BaseActivity(), View.OnClickListener {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == PIN_REQUEST_CODE) {
-            if (resultCode == PinActivity.SUCCESS_PIN && data != null) {
-                val pin = data.getStringExtra(PinActivity.KEY_PIN)
-
-                AccountUtils.generateWallet(applicationContext, mnemonicString, passphrase, pin)
-
+        if (requestCode == CREATE_WALLET_REQUEST) {
+            if (resultCode == Activity.RESULT_OK) {
                 launchWallet()
             }
         }
@@ -67,7 +62,7 @@ class MnemonicActivity : BaseActivity(), View.OnClickListener {
     override fun onClick(v: View) {
         val itemId = v.id
         when (itemId) {
-            R.id.confirmButton -> launchPINView(PinType.CREATE, getString(R.string.please_create_a_pin), mnemonicString, passphrase)
+            R.id.confirmButton -> startActivityForResult(WalletManagerActivity.createWallet(v.context, mnemonicString, passphrase), CREATE_WALLET_REQUEST)
             R.id.passphraseButton -> {
                 val builder = PassphraseDialogHelper(this, object: PassphraseDialogHelper.PassphraseDialogListener {
                     override fun onOK(phrase: String) {

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/RecoverWalletActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/RecoverWalletActivity.kt
@@ -1,5 +1,7 @@
 package com.blockeq.stellarwallet.activities
 
+import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.support.v4.content.ContextCompat
@@ -16,29 +18,33 @@ import com.blockeq.stellarwallet.utils.AccountUtils
 import com.soneso.stellarmnemonics.mnemonic.WordList
 import kotlinx.android.synthetic.main.activity_recover_wallet.*
 
-
 class RecoverWalletActivity : BaseActivity() {
-
     private var isRecoveryPhrase = true
     private var passphrase : String? = null
     private lateinit var recoveryString : String
+    private val RESTORE_REQUEST = 0x01
+
+    companion object {
+        private var INTENT_ARG_RECOVERY = "INTENT_ARG_RECOVERY"
+        fun newInstance(context: Context, isRecovery: Boolean) : Intent {
+            val intent = Intent(context, RecoverWalletActivity::class.java)
+            intent.putExtra(INTENT_ARG_RECOVERY, isRecovery)
+            return intent
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_recover_wallet)
 
-        isRecoveryPhrase = intent.getBooleanExtra("isPhraseRecovery", true)
+        isRecoveryPhrase = intent.getBooleanExtra(INTENT_ARG_RECOVERY, true)
         setupUI()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == PIN_REQUEST_CODE) {
-            if (resultCode == PinActivity.SUCCESS_PIN && data != null) {
-                val pin = data.getStringExtra(PinActivity.KEY_PIN)
-
-                AccountUtils.generateWallet(applicationContext, recoveryString, passphrase, pin)
-
+        if (requestCode == RESTORE_REQUEST) {
+            if (resultCode ==  Activity.RESULT_OK) {
                 launchWallet()
             }
         }
@@ -75,10 +81,7 @@ class RecoverWalletActivity : BaseActivity() {
 
                 recoveryString = StellarRecoveryString(getMnemonicString(), isRecoveryPhrase, passphrase).getString()
 
-                launchPINView(PinType.CREATE,
-                        getString(R.string.please_create_a_pin),
-                        recoveryString,
-                        passphrase)
+                startActivityForResult(WalletManagerActivity.restore(it.context, recoveryString, passphrase), RESTORE_REQUEST)
             } catch (e: Exception) {
                 showErrorMessage(e.message)
             }
@@ -109,12 +112,13 @@ class RecoverWalletActivity : BaseActivity() {
 
     private fun setupToolbar() {
         setSupportActionBar(findViewById(R.id.recoverToolbar))
-        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
-
-        supportActionBar!!.title = if (isRecoveryPhrase) {
-            getString(R.string.enter_phrase)
-        } else {
-            getString(R.string.enter_secret_key)
+        supportActionBar?.let {
+            it.setDisplayHomeAsUpEnabled(true)
+            it.title = if (isRecoveryPhrase) {
+                getString(R.string.enter_phrase)
+            } else {
+                getString(R.string.enter_secret_key)
+            }
         }
     }
 

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/SendActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/SendActivity.kt
@@ -20,7 +20,6 @@ import com.blockeq.stellarwallet.WalletApplication
 import com.blockeq.stellarwallet.interfaces.SuccessErrorCallback
 import com.blockeq.stellarwallet.models.ExchangeApiModel
 import com.blockeq.stellarwallet.models.HorizonException
-import com.blockeq.stellarwallet.models.PinType
 import com.blockeq.stellarwallet.remote.Horizon
 import com.blockeq.stellarwallet.utils.AccountUtils
 import com.blockeq.stellarwallet.utils.NetworkUtils
@@ -36,6 +35,7 @@ class SendActivity : BaseActivity(), NumberKeyboardListener, SuccessErrorCallbac
     companion object {
         private const val MAX_ALLOWED_DECIMALS = 7
         private const val ARG_ADDRESS_DATA = "ARG_ADDRESS_DATA"
+        private const val REQUEST_PIN = 0x0
 
         fun newIntent(context: Context, address: String): Intent {
             val intent = Intent(context, SendActivity::class.java)
@@ -77,7 +77,7 @@ class SendActivity : BaseActivity(), NumberKeyboardListener, SuccessErrorCallbac
         send_button.setOnClickListener {
             if (isAmountValid()) {
                 if (WalletApplication.localStore.showPinOnSend) {
-                    launchPINView(PinType.CHECK, "", "", null)
+                   startActivityForResult(SimplePinActivity.newInstance(it.context), REQUEST_PIN)
                 } else {
                     sendPayment()
                 }
@@ -105,11 +105,11 @@ class SendActivity : BaseActivity(), NumberKeyboardListener, SuccessErrorCallbac
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == PinActivity.PIN_REQUEST_CODE) {
-            when (resultCode) {
-                PinActivity.SUCCESS_VOID -> sendPayment()
-                Activity.RESULT_CANCELED -> {}
-                else -> finish()
+        if (requestCode == REQUEST_PIN) {
+            if (resultCode == Activity.RESULT_OK) {
+                sendPayment()
+            } else {
+                finish()
             }
         }
     }

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/SendActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/SendActivity.kt
@@ -77,7 +77,7 @@ class SendActivity : BaseActivity(), NumberKeyboardListener, SuccessErrorCallbac
         send_button.setOnClickListener {
             if (isAmountValid()) {
                 if (WalletApplication.localStore.showPinOnSend) {
-                   startActivityForResult(SimplePinActivity.newInstance(it.context), REQUEST_PIN)
+                   startActivityForResult(WalletManagerActivity.verifyPin(it.context), REQUEST_PIN)
                 } else {
                     sendPayment()
                 }

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/SimplePinActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/SimplePinActivity.kt
@@ -1,0 +1,121 @@
+package com.blockeq.stellarwallet.activities
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.view.View
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
+import com.andrognito.pinlockview.PinLockListener
+import com.blockeq.stellarwallet.R
+import com.blockeq.stellarwallet.WalletApplication
+import com.blockeq.stellarwallet.utils.AccountUtils
+import kotlinx.android.synthetic.main.activity_pin.*
+import timber.log.Timber
+import java.lang.IllegalStateException
+
+class SimplePinActivity : BaseActivity(), PinLockListener {
+
+    private var numAttempts = 0
+    private val MAX_ATTEMPTS = 3
+    private lateinit var appContext : Context
+
+    companion object {
+        private const val INTENT_ARG_MESSAGE: String = "INTENT_ARG_MESSAGE"
+        private const val INTENT_ARG_PIN: String = "INTENT_ARG_PIN"
+
+        fun newInstance(context: Context, message: String = context.getString(R.string.please_enter_your_pin)): Intent {
+            val intent = Intent(context, SimplePinActivity::class.java)
+            intent.putExtra(INTENT_ARG_MESSAGE, message)
+            return intent
+        }
+
+        fun getPinFromIntent(intent:Intent) : String? {
+            return intent.getStringExtra(INTENT_ARG_PIN)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_pin)
+
+        appContext = applicationContext
+
+        pinLockView.setPinLockListener(this)
+        pinLockView.attachIndicatorDots(indicatorDots)
+
+        if (!intent.hasExtra(INTENT_ARG_MESSAGE)) throw IllegalStateException("missing argument {$INTENT_ARG_MESSAGE}, did you use #newInstance(..)?")
+        val message = intent.getStringExtra(INTENT_ARG_MESSAGE)
+        customMessageTextView.text = message
+    }
+
+    override fun onEmpty() {}
+
+    override fun onComplete(pin: String) {
+        Timber.d("OnComplete")
+        val handler = Handler()
+        val runnableCode = Runnable {
+            val foundMasterKey = AccountUtils.getPinMasterKey(appContext, pin)
+            if (foundMasterKey != null) {
+                val intent = Intent()
+                intent.putExtra(INTENT_ARG_PIN, pin)
+                setResult(Activity.RESULT_OK, intent)
+                finishPinActivity()
+            } else {
+                onIncorrectPin()
+            }
+        }
+        //TODO move the work to non ui Thread, this delay is to not freeze the animation of the last pin dot.
+        handler.postDelayed(runnableCode, 200)
+    }
+
+    //region User Interface
+
+    override fun onPinChange(pinLength: Int, intermediatePin: String?) {}
+
+    private fun onIncorrectPin() {
+        showWrongPinDots(true)
+        val shakeAnimation = AnimationUtils.loadAnimation(this, R.anim.shake)
+        shakeAnimation.setAnimationListener(object : Animation.AnimationListener {
+            override fun onAnimationStart(arg0: Animation) {}
+            override fun onAnimationRepeat(arg0: Animation) {}
+            override fun onAnimationEnd(arg0: Animation) {
+                showWrongPinDots(false)
+                pinLockView.resetPinLockView()
+                numAttempts++
+                customMessageTextView.text = resources.getQuantityString(R.plurals.attempts_template,
+                        MAX_ATTEMPTS - numAttempts, MAX_ATTEMPTS - numAttempts)
+                if (numAttempts == MAX_ATTEMPTS) {
+                    wipeAndRestart()
+                }
+            }
+        })
+        wrongPinDots.startAnimation(shakeAnimation)
+    }
+
+    private fun showWrongPinDots(show: Boolean) {
+        indicatorDots.visibility = if (show) View.GONE else View.VISIBLE
+        wrongPinDots.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    override fun onBackPressed() {
+        setResult(RESULT_CANCELED)
+        super.onBackPressed()
+        overridePendingTransition(R.anim.stay, R.anim.slide_out_down)
+    }
+
+    private fun wipeAndRestart() {
+        AccountUtils.wipe(this)
+        val intent = Intent(this, LaunchActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        startActivity(intent)
+    }
+
+    private fun finishPinActivity() {
+        overridePendingTransition(R.anim.stay, R.anim.slide_out_down)
+        finish()
+    }
+    //endregion
+}

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/SimplePinActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/SimplePinActivity.kt
@@ -4,36 +4,44 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.os.Handler
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
-import com.andrognito.pinlockview.PinLockListener
 import com.blockeq.stellarwallet.R
-import com.blockeq.stellarwallet.WalletApplication
+import com.blockeq.stellarwallet.interfaces.OnPinLockCompleteListener
 import com.blockeq.stellarwallet.utils.AccountUtils
 import kotlinx.android.synthetic.main.activity_pin.*
 import timber.log.Timber
-import java.lang.IllegalStateException
 
-class SimplePinActivity : BaseActivity(), PinLockListener {
+class SimplePinActivity : BaseActivity() {
 
     private var numAttempts = 0
     private val MAX_ATTEMPTS = 3
+    private var PIN : String? = null
     private lateinit var appContext : Context
 
     companion object {
         private const val INTENT_ARG_MESSAGE: String = "INTENT_ARG_MESSAGE"
         private const val INTENT_ARG_PIN: String = "INTENT_ARG_PIN"
+        private const val INTENT_ARG_PIN_RESULT: String = "INTENT_ARG_PIN_RESULT"
 
-        fun newInstance(context: Context, message: String = context.getString(R.string.please_enter_your_pin)): Intent {
+        /**
+         * New Instance of Intent to launch a {@link SimplePinActivity}
+         * @param context the activityContext of the requestor
+         * @param PIN pin to verified otherwise it will simple return the inserted pin.
+         * @param message message to show on the top of the pinlock.
+         */
+        fun newInstance(context: Context, PIN : String?, message: String = context.getString(R.string.please_enter_your_pin)): Intent {
             val intent = Intent(context, SimplePinActivity::class.java)
-            intent.putExtra(INTENT_ARG_MESSAGE, message)
+                intent.putExtra(INTENT_ARG_MESSAGE, message)
+            if (PIN != null) {
+                intent.putExtra(INTENT_ARG_PIN, PIN)
+            }
             return intent
         }
 
         fun getPinFromIntent(intent:Intent) : String? {
-            return intent.getStringExtra(INTENT_ARG_PIN)
+            return intent.getStringExtra(INTENT_ARG_PIN_RESULT)
         }
     }
 
@@ -43,39 +51,34 @@ class SimplePinActivity : BaseActivity(), PinLockListener {
 
         appContext = applicationContext
 
-        pinLockView.setPinLockListener(this)
+        pinLockView.setPinLockListener(object : OnPinLockCompleteListener() {
+            override fun onComplete(pin: String?) {
+                Timber.d("OnComplete")
+                if (PIN == null || PIN == pin) {
+                    val intent = Intent()
+                    intent.putExtra(INTENT_ARG_PIN_RESULT, pin)
+                    setResult(Activity.RESULT_OK, intent)
+                    overridePendingTransition(R.anim.stay, R.anim.slide_out_down)
+                    finish()
+                } else {
+                    processIncorrectPin()
+                }
+            }
+        })
+
         pinLockView.attachIndicatorDots(indicatorDots)
 
         if (!intent.hasExtra(INTENT_ARG_MESSAGE)) throw IllegalStateException("missing argument {$INTENT_ARG_MESSAGE}, did you use #newInstance(..)?")
+
         val message = intent.getStringExtra(INTENT_ARG_MESSAGE)
         customMessageTextView.text = message
-    }
 
-    override fun onEmpty() {}
-
-    override fun onComplete(pin: String) {
-        Timber.d("OnComplete")
-        val handler = Handler()
-        val runnableCode = Runnable {
-            val foundMasterKey = AccountUtils.getPinMasterKey(appContext, pin)
-            if (foundMasterKey != null) {
-                val intent = Intent()
-                intent.putExtra(INTENT_ARG_PIN, pin)
-                setResult(Activity.RESULT_OK, intent)
-                finishPinActivity()
-            } else {
-                onIncorrectPin()
-            }
-        }
-        //TODO move the work to non ui Thread, this delay is to not freeze the animation of the last pin dot.
-        handler.postDelayed(runnableCode, 200)
+        PIN = intent.getStringExtra(INTENT_ARG_PIN_RESULT)
     }
 
     //region User Interface
 
-    override fun onPinChange(pinLength: Int, intermediatePin: String?) {}
-
-    private fun onIncorrectPin() {
+    private fun processIncorrectPin() {
         showWrongPinDots(true)
         val shakeAnimation = AnimationUtils.loadAnimation(this, R.anim.shake)
         shakeAnimation.setAnimationListener(object : Animation.AnimationListener {
@@ -111,11 +114,6 @@ class SimplePinActivity : BaseActivity(), PinLockListener {
         val intent = Intent(this, LaunchActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
         startActivity(intent)
-    }
-
-    private fun finishPinActivity() {
-        overridePendingTransition(R.anim.stay, R.anim.slide_out_down)
-        finish()
     }
     //endregion
 }

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/ViewSecretSeedActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/ViewSecretSeedActivity.kt
@@ -3,6 +3,7 @@ package com.blockeq.stellarwallet.activities
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.widget.Toast
@@ -12,20 +13,27 @@ import kotlinx.android.synthetic.main.activity_view_secret_seed.*
 class ViewSecretSeedActivity : BaseActivity() {
 
     companion object {
-        const val SECRET_SEED = "kSecretSeed"
+        private const val ARG_SECRET_SEED = "ARG_SECRET_SEED"
+        fun newInstance(context: Context, secretSeed : String) : Intent {
+            val intent = Intent(context, ViewSecretSeedActivity::class.java)
+            intent.putExtra(ARG_SECRET_SEED, secretSeed)
+            return intent
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_view_secret_seed)
 
+         intent?.extras?.let{
+            val secretSeed = it.getString(ARG_SECRET_SEED)
+            secretSeed?.let {
+                secretSeedTextView.text = secretSeed
+                copyImageButton.setOnClickListener { copyAddressToClipBoard(secretSeed)  }
+            }
+        }
         setSupportActionBar(toolBar)
-        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
-
-        val secretSeed = intent!!.extras.getString(SECRET_SEED)
-
-        secretSeedTextView.text = secretSeed
-        copyImageButton.setOnClickListener { copyAddressToClipBoard(secretSeed)  }
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
     private fun copyAddressToClipBoard(data: String) {

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/WalletManagerActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/WalletManagerActivity.kt
@@ -7,19 +7,25 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import com.blockeq.stellarwallet.R
 import com.blockeq.stellarwallet.WalletApplication
-import com.blockeq.stellarwallet.activities.PinActivity.Companion.PIN_REQUEST_CODE
-import com.blockeq.stellarwallet.fragments.SettingsFragment
+import com.blockeq.stellarwallet.encryption.KeyStoreWrapper
 import com.blockeq.stellarwallet.utils.AccountUtils
 import java.lang.IllegalStateException
 
 class WalletManagerActivity : AppCompatActivity() {
     private enum class ActionType {
-        CREATE,
-        RESTORE,
+        NEW_WALLET,
+        RESTORE_WALLET,
         VERIFY_PIN,
         DECRYPT_SECRET_SEED,
-        DECRYPT_MNEMONIC
+        DECRYPT_MNEMONIC,
+        /**
+         * These are interim action types used in the actions NEW_WALLET & RESTORE_WALLET
+         */
+        ENTER_PIN,
+        REENTER_PIN,
     }
+
+    private lateinit var actionType : ActionType
 
     companion object {
         private const val INTENT_ARG_TYPE: String = "INTENT_ARG_TYPE"
@@ -30,6 +36,7 @@ class WalletManagerActivity : AppCompatActivity() {
 
         fun createWallet(context: Context, mnemonicString: String, passphrase: String?): Intent {
             val intent = Intent(context, WalletManagerActivity::class.java)
+            intent.putExtra(INTENT_ARG_TYPE, ActionType.NEW_WALLET)
             intent.putExtra(INTENT_MNEMONIC_TYPE, mnemonicString)
             if (passphrase != null) {
                 intent.putExtra(INTENT_PASSPHRASE, passphrase)
@@ -39,7 +46,7 @@ class WalletManagerActivity : AppCompatActivity() {
 
         fun restore(context: Context, recoveryString: String, passphrase: String?): Intent {
             val intent = Intent(context, WalletManagerActivity::class.java)
-            intent.putExtra(INTENT_ARG_TYPE, ActionType.RESTORE)
+            intent.putExtra(INTENT_ARG_TYPE, ActionType.RESTORE_WALLET)
             intent.putExtra(INTENT_RECOVERY, recoveryString)
             if (passphrase != null) {
                 intent.putExtra(INTENT_PASSPHRASE, passphrase)
@@ -70,42 +77,75 @@ class WalletManagerActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (!intent.hasExtra(INTENT_ARG_TYPE)) throw IllegalStateException("missing bundle extra {$INTENT_ARG_TYPE}")
-        val type = intent.getSerializableExtra(INTENT_ARG_TYPE)
-        when(type) {
-            ActionType.CREATE -> {
-
-            }
-
-            ActionType.DECRYPT_MNEMONIC -> {
-                startActivityForResult(SimplePinActivity.newInstance(this, getString(R.string.please_enter_your_pin)), ActionType.DECRYPT_MNEMONIC.ordinal)
-            }
-            ActionType.DECRYPT_SECRET_SEED -> {
-                startActivityForResult(SimplePinActivity.newInstance(this, getString(R.string.please_enter_your_pin)), ActionType.DECRYPT_SECRET_SEED.ordinal)
-            }
-            ActionType.VERIFY_PIN -> startActivityForResult(SimplePinActivity.newInstance(this, getString(R.string.please_enter_your_pin)), ActionType.VERIFY_PIN.ordinal)
+        intent.getSerializableExtra(INTENT_ARG_TYPE)?.let {
+            actionType = it as ActionType
         }
 
+        when(actionType) {
+            ActionType.RESTORE_WALLET,
+            ActionType.NEW_WALLET -> {
+                startActivityForResult(SimplePinActivity.newInstance(this, null, getString(R.string.please_create_a_pin)), ActionType.ENTER_PIN.ordinal)
+            }
+            ActionType.DECRYPT_MNEMONIC -> {
+                startActivityForResult(SimplePinActivity.newInstance(this, getPinFromKeyStore(), getString(R.string.please_enter_your_pin)), ActionType.DECRYPT_MNEMONIC.ordinal)
+            }
+            ActionType.DECRYPT_SECRET_SEED -> {
+                startActivityForResult(SimplePinActivity.newInstance(this, getPinFromKeyStore(), getString(R.string.please_enter_your_pin)), ActionType.DECRYPT_SECRET_SEED.ordinal)
+            }
+            ActionType.VERIFY_PIN -> {
+                startActivityForResult(SimplePinActivity.newInstance(this, getPinFromKeyStore(), getString(R.string.please_enter_your_pin)), ActionType.VERIFY_PIN.ordinal)
+            } else -> {
+                throw IllegalStateException("invalid action type $actionType")
+            }
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {
+            ActionType.ENTER_PIN.ordinal -> {
+                startActivityForResult(SimplePinActivity.newInstance(this, getString(R.string.please_reenter_your_pin)), ActionType.REENTER_PIN.ordinal)
+                return
+            }
+            ActionType.REENTER_PIN.ordinal -> {
+                when(actionType) {
+                    ActionType.NEW_WALLET -> {
+                        val mnemonicString = intent.getStringExtra(INTENT_MNEMONIC_TYPE)
+                        if (generateWallet(data, mnemonicString)) {
+                            setResult(Activity.RESULT_OK)
+                            finish()
+                            return
+                        }
+                    }
+                    ActionType.RESTORE_WALLET -> {
+                        val recovery = intent.getStringExtra(INTENT_RECOVERY)
+                        if (generateWallet(data, recovery)) {
+                            setResult(Activity.RESULT_OK)
+                            finish()
+                            return
+                        }
+                    }
+                    else -> {}
+                }
+            }
             ActionType.VERIFY_PIN.ordinal -> {
                 if (resultCode == Activity.RESULT_OK) {
                     setResult(Activity.RESULT_OK)
                     finish()
+                    return
                 }
             }
             ActionType.DECRYPT_MNEMONIC.ordinal -> {
                 if (resultCode == Activity.RESULT_OK && data != null) {
                     val pin = SimplePinActivity.getPinFromIntent(data)
                     if (pin != null) {
-                        val foundMasterKey = AccountUtils.getPinMasterKey(applicationContext, pin)
-                        if (foundMasterKey != null) {
+                        val masterKey = AccountUtils.getPinMasterKey(applicationContext, pin)
+                        if (masterKey != null) {
                             val encryptedPhrase = WalletApplication.localStore.encryptedPhrase!!
-                            val decryptedPhrase = AccountUtils.getDecryptedString(encryptedPhrase, foundMasterKey)
+                            val decryptedPhrase = AccountUtils.getDecryptedString(encryptedPhrase, masterKey)
                             startActivity(MnemonicActivity.newDisplayMnemonicIntent(this, decryptedPhrase))
                             finish()
+                            return
                         }
                     }
                 }
@@ -114,28 +154,46 @@ class WalletManagerActivity : AppCompatActivity() {
                 if (resultCode == Activity.RESULT_OK && data != null) {
                     val pin = SimplePinActivity.getPinFromIntent(data)
                     if (pin != null) {
-                        val foundMasterKey = AccountUtils.getPinMasterKey(applicationContext, pin)
-                        if (foundMasterKey != null) {
+                        val masterKey = AccountUtils.getPinMasterKey(applicationContext, pin)
+                        if (masterKey != null) {
                             val encryptedPhrase = WalletApplication.localStore.encryptedPhrase!!
+                            val phrase = AccountUtils.getDecryptedString(encryptedPhrase, masterKey)
+
                             val encryptedPassphrase = WalletApplication.localStore.encryptedPassphrase
-                            val decryptedPhrase = AccountUtils.getDecryptedString(encryptedPhrase, foundMasterKey)
-                            var decryptedPassphrase : String? = null
+                            var passphrase: String?= null
                             if (encryptedPassphrase != null) {
-                                decryptedPassphrase = AccountUtils.getDecryptedString(encryptedPassphrase, foundMasterKey)
+                                passphrase = AccountUtils.getDecryptedString(encryptedPassphrase, masterKey)
                             }
-
-                            val keyPair = AccountUtils.getStellarKeyPair(decryptedPhrase, decryptedPassphrase)
+                            val keyPair = AccountUtils.getStellarKeyPair(phrase, passphrase)
                             val secretSeed = keyPair.secretSeed.joinToString("")
-                            val intent = Intent(this, ViewSecretSeedActivity::class.java)
-
-                            intent.putExtra(ViewSecretSeedActivity.SECRET_SEED, secretSeed)
-                            startActivity(intent)
+                            startActivity(ViewSecretSeedActivity.newInstance(this, secretSeed))
                             finish()
+                            return
                         }
                     }
                 }
             }
         }
+
+        setResult(Activity.RESULT_CANCELED)
+        finish()
+    }
+
+    private fun getPinFromKeyStore() : String {
+        return KeyStoreWrapper(applicationContext).getAliases().first()
+    }
+
+    private fun generateWallet(data:Intent?, secret: String) : Boolean {
+        data?.let {
+            val pin = SimplePinActivity.getPinFromIntent(it)
+            val passphrase = intent.getStringExtra(INTENT_PASSPHRASE)
+
+            pin?.let { that ->
+                AccountUtils.generateWallet(applicationContext, secret, passphrase, that)
+                return true
+            }
+        }
+        return false
     }
 }
 

--- a/app/src/main/java/com/blockeq/stellarwallet/activities/WalletManagerActivity.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/activities/WalletManagerActivity.kt
@@ -1,0 +1,141 @@
+package com.blockeq.stellarwallet.activities
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import com.blockeq.stellarwallet.R
+import com.blockeq.stellarwallet.WalletApplication
+import com.blockeq.stellarwallet.activities.PinActivity.Companion.PIN_REQUEST_CODE
+import com.blockeq.stellarwallet.fragments.SettingsFragment
+import com.blockeq.stellarwallet.utils.AccountUtils
+import java.lang.IllegalStateException
+
+class WalletManagerActivity : AppCompatActivity() {
+    private enum class ActionType {
+        CREATE,
+        RESTORE,
+        VERIFY_PIN,
+        DECRYPT_SECRET_SEED,
+        DECRYPT_MNEMONIC
+    }
+
+    companion object {
+        private const val INTENT_ARG_TYPE: String = "INTENT_ARG_TYPE"
+
+        private const val INTENT_MNEMONIC_TYPE: String = "INTENT_MNEMONIC_TYPE"
+        private const val INTENT_PASSPHRASE: String = "INTENT_PASSPHRASE"
+        private const val INTENT_RECOVERY: String = "INTENT_RECOVERY"
+
+        fun createWallet(context: Context, mnemonicString: String, passphrase: String?): Intent {
+            val intent = Intent(context, WalletManagerActivity::class.java)
+            intent.putExtra(INTENT_MNEMONIC_TYPE, mnemonicString)
+            if (passphrase != null) {
+                intent.putExtra(INTENT_PASSPHRASE, passphrase)
+            }
+            return intent
+        }
+
+        fun restore(context: Context, recoveryString: String, passphrase: String?): Intent {
+            val intent = Intent(context, WalletManagerActivity::class.java)
+            intent.putExtra(INTENT_ARG_TYPE, ActionType.RESTORE)
+            intent.putExtra(INTENT_RECOVERY, recoveryString)
+            if (passphrase != null) {
+                intent.putExtra(INTENT_PASSPHRASE, passphrase)
+            }
+            return intent
+        }
+
+        fun verifyPin(context: Context) : Intent {
+            val intent = Intent(context, WalletManagerActivity::class.java)
+            intent.putExtra(INTENT_ARG_TYPE, ActionType.VERIFY_PIN)
+            return intent
+        }
+
+        fun showSecretSeed(context: Context) : Intent {
+            val intent = Intent(context, WalletManagerActivity::class.java)
+            intent.putExtra(INTENT_ARG_TYPE, ActionType.DECRYPT_SECRET_SEED)
+            return intent
+        }
+
+        fun showMnemonic(context: Context) : Intent {
+            val intent = Intent(context, WalletManagerActivity::class.java)
+            intent.putExtra(INTENT_ARG_TYPE, ActionType.DECRYPT_MNEMONIC)
+            return intent
+        }
+    }
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (!intent.hasExtra(INTENT_ARG_TYPE)) throw IllegalStateException("missing bundle extra {$INTENT_ARG_TYPE}")
+        val type = intent.getSerializableExtra(INTENT_ARG_TYPE)
+        when(type) {
+            ActionType.CREATE -> {
+
+            }
+
+            ActionType.DECRYPT_MNEMONIC -> {
+                startActivityForResult(SimplePinActivity.newInstance(this, getString(R.string.please_enter_your_pin)), ActionType.DECRYPT_MNEMONIC.ordinal)
+            }
+            ActionType.DECRYPT_SECRET_SEED -> {
+                startActivityForResult(SimplePinActivity.newInstance(this, getString(R.string.please_enter_your_pin)), ActionType.DECRYPT_SECRET_SEED.ordinal)
+            }
+            ActionType.VERIFY_PIN -> startActivityForResult(SimplePinActivity.newInstance(this, getString(R.string.please_enter_your_pin)), ActionType.VERIFY_PIN.ordinal)
+        }
+
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        when (requestCode) {
+            ActionType.VERIFY_PIN.ordinal -> {
+                if (resultCode == Activity.RESULT_OK) {
+                    setResult(Activity.RESULT_OK)
+                    finish()
+                }
+            }
+            ActionType.DECRYPT_MNEMONIC.ordinal -> {
+                if (resultCode == Activity.RESULT_OK && data != null) {
+                    val pin = SimplePinActivity.getPinFromIntent(data)
+                    if (pin != null) {
+                        val foundMasterKey = AccountUtils.getPinMasterKey(applicationContext, pin)
+                        if (foundMasterKey != null) {
+                            val encryptedPhrase = WalletApplication.localStore.encryptedPhrase!!
+                            val decryptedPhrase = AccountUtils.getDecryptedString(encryptedPhrase, foundMasterKey)
+                            startActivity(MnemonicActivity.newDisplayMnemonicIntent(this, decryptedPhrase))
+                            finish()
+                        }
+                    }
+                }
+            }
+            ActionType.DECRYPT_SECRET_SEED.ordinal -> {
+                if (resultCode == Activity.RESULT_OK && data != null) {
+                    val pin = SimplePinActivity.getPinFromIntent(data)
+                    if (pin != null) {
+                        val foundMasterKey = AccountUtils.getPinMasterKey(applicationContext, pin)
+                        if (foundMasterKey != null) {
+                            val encryptedPhrase = WalletApplication.localStore.encryptedPhrase!!
+                            val encryptedPassphrase = WalletApplication.localStore.encryptedPassphrase
+                            val decryptedPhrase = AccountUtils.getDecryptedString(encryptedPhrase, foundMasterKey)
+                            var decryptedPassphrase : String? = null
+                            if (encryptedPassphrase != null) {
+                                decryptedPassphrase = AccountUtils.getDecryptedString(encryptedPassphrase, foundMasterKey)
+                            }
+
+                            val keyPair = AccountUtils.getStellarKeyPair(decryptedPhrase, decryptedPassphrase)
+                            val secretSeed = keyPair.secretSeed.joinToString("")
+                            val intent = Intent(this, ViewSecretSeedActivity::class.java)
+
+                            intent.putExtra(ViewSecretSeedActivity.SECRET_SEED, secretSeed)
+                            startActivity(intent)
+                            finish()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/blockeq/stellarwallet/encryption/KeyStoreWrapper.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/encryption/KeyStoreWrapper.kt
@@ -45,6 +45,9 @@ class KeyStoreWrapper(private val context: Context) {
         }
     }
 
+    fun getAliases() : List<String> {
+        return Collections.list(keyStore.aliases())
+    }
     /**
      * @return asymmetric keypair from Android Key Store or null if any key with given alias exists
      */

--- a/app/src/main/java/com/blockeq/stellarwallet/fragments/SettingsFragment.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/fragments/SettingsFragment.kt
@@ -1,6 +1,7 @@
 package com.blockeq.stellarwallet.fragments
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -10,15 +11,17 @@ import android.view.ViewGroup
 import com.blockeq.stellarwallet.BuildConfig
 import com.blockeq.stellarwallet.R
 import com.blockeq.stellarwallet.WalletApplication
-import com.blockeq.stellarwallet.activities.DebugPreferenceActivity
-import com.blockeq.stellarwallet.activities.DiagnosticActivity
-import com.blockeq.stellarwallet.activities.WebViewActivity
-import com.blockeq.stellarwallet.models.PinType
+import com.blockeq.stellarwallet.activities.*
+import com.blockeq.stellarwallet.utils.AccountUtils
 import com.blockeq.stellarwallet.utils.DiagnosticUtils
 import kotlinx.android.synthetic.main.fragment_settings.*
 
 class SettingsFragment : BaseFragment() {
     private lateinit var appContext : Context
+
+    enum class SettingsAction {
+        CLEAR_WALLET, TOGGLE_PIN_ON_SENDING
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_settings, container, false)
@@ -44,19 +47,19 @@ class SettingsFragment : BaseFragment() {
         val phrase = WalletApplication.localStore.encryptedPhrase!!
         
         viewPhraseButton.setOnClickListener {
-            launchPINView(PinType.VIEW_PHRASE, "", phrase)
+            startActivity(WalletManagerActivity.showMnemonic(it.context))
         }
 
         viewSeedButton.setOnClickListener {
-            launchPINView(PinType.VIEW_SEED, "", phrase)
+            startActivity(WalletManagerActivity.showSecretSeed(it.context))
         }
 
         clearWalletButton.setOnClickListener {
-            launchPINView(PinType.CLEAR_WALLET, "", phrase)
+            startActivityForResult(WalletManagerActivity.verifyPin(it.context), SettingsAction.CLEAR_WALLET.ordinal)
         }
 
         pinOnSendPaymentsButton.setOnClickListener {
-            launchPINView(PinType.TOGGLE_PIN_ON_SENDING, "", phrase)
+            startActivityForResult(WalletManagerActivity.verifyPin(it.context), SettingsAction.TOGGLE_PIN_ON_SENDING.ordinal)
         }
 
         diagnosticButton.setOnClickListener {
@@ -87,8 +90,33 @@ class SettingsFragment : BaseFragment() {
         appVersionTextView.text = "Version: $appVersion"
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        when(requestCode) {
+            SettingsAction.CLEAR_WALLET.ordinal -> {
+                if (resultCode == Activity.RESULT_OK) {
+                    wipeAndRestart()
+                }
+            }
+
+            SettingsAction.TOGGLE_PIN_ON_SENDING.ordinal -> {
+                if (resultCode == Activity.RESULT_OK) {
+                    WalletApplication.localStore.showPinOnSend = !WalletApplication.localStore.showPinOnSend
+                }
+            }
+        }
+    }
+
     private fun setSavedSettings() {
         pinOnSendPaymentsButton.isChecked = WalletApplication.localStore.showPinOnSend
+    }
+
+    private fun wipeAndRestart() {
+        activity?.let {
+            AccountUtils.wipe(appContext)
+            val intent = Intent(activity, LaunchActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            startActivity(intent)
+        }
     }
 
 }

--- a/app/src/main/java/com/blockeq/stellarwallet/fragments/SettingsFragment.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/fragments/SettingsFragment.kt
@@ -44,8 +44,6 @@ class SettingsFragment : BaseFragment() {
     }
 
     private fun setupUI() {
-        val phrase = WalletApplication.localStore.encryptedPhrase!!
-        
         viewPhraseButton.setOnClickListener {
             startActivity(WalletManagerActivity.showMnemonic(it.context))
         }

--- a/app/src/main/java/com/blockeq/stellarwallet/interfaces/OnPinLockCompleteListener.java
+++ b/app/src/main/java/com/blockeq/stellarwallet/interfaces/OnPinLockCompleteListener.java
@@ -1,0 +1,15 @@
+package com.blockeq.stellarwallet.interfaces;
+
+import com.andrognito.pinlockview.PinLockListener;
+
+public abstract class OnPinLockCompleteListener implements PinLockListener {
+    @Override
+    public void onEmpty() {
+        // empty
+    }
+
+    @Override
+    public void onPinChange(int pinLength, String intermediatePin) {
+        // empty
+    }
+}

--- a/app/src/main/java/com/blockeq/stellarwallet/models/PinViewState.kt
+++ b/app/src/main/java/com/blockeq/stellarwallet/models/PinViewState.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 enum class PinType {
-    CREATE, LOGIN, VIEW_PHRASE, VIEW_SEED, CLEAR_WALLET, CHECK, TOGGLE_PIN_ON_SENDING
+    CREATE, LOGIN, VIEW_PHRASE, VIEW_SEED, CHECK,
 }
 
 @Parcelize


### PR DESCRIPTION
@Daniel-Wang  review this.. I created a `SimplePinActivity` that returns RESULT_OK or RESULT_CANCEL. I moved all the logic to the transaprent activity `WalletManagerActivity`.

No more public request codes, intent argument names, ... everything is in static method like new instance like this.

```
WalletManagerActivity.createWallet(...)
WalletManagerActivity.restore(...)
WalletManagerActivity.verifyPin(...)
WalletManagerActivity.showSecretSeed
WalletManagerActivity.showMnemonic
```

WalletManagerActivity acts as router too, it is opening the activities that result of the operation.