### PR TITLE
[FIX] Update link to contributing docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - [Introduction](#introduction)
 - [Features](#features)
 - [Feedback](#feedback)
-- [Contributors](#contributors)
+- [Contributing](./CONTRIBUTING.md)
 - [Development](#development)
   - [Getting Started](#getting-started)
   - [Building the Project](#building-the-project)


### PR DESCRIPTION
## Priority

Low

## Description

I noticed the `Contributors` link in the table of contents was broken, so I pointed it to the `CONTRIBUTING.md` document.